### PR TITLE
return on invalid price

### DIFF
--- a/src/sportsclient/ws.go
+++ b/src/sportsclient/ws.go
@@ -77,12 +77,20 @@ func (sp *SportsClient) handleMessage(v *Envelope) {
 	if v.Type != "odds" {
 		return
 	}
-	if v.Data.IndexPrice == "nil" {
-		slog.Info("index price nil", "id", v.Data.ContractID)
-	}
 	px, err := strconv.ParseFloat(v.Data.IndexPrice, 64)
 	if err != nil {
-		slog.Error("invalid price", "price", v.Data.IndexPrice)
+		if v.Data.IndexPrice == "" || v.Data.IndexPrice == "nil" {
+			slog.Info("empty price, skipping",
+				"price", v.Data.IndexPrice,
+				"contractId", v.Data.ContractID,
+				"event_status", v.Data.EventStatus)
+		} else {
+			slog.Error("unparseable price from broker",
+				"price", v.Data.IndexPrice,
+				"contractId", v.Data.ContractID,
+				"event_status", v.Data.EventStatus)
+		}
+		return
 	}
 	slotName, isLive := sp.SdkRO.SportSlot(v.Data.ContractID)
 	if !isLive {


### PR DESCRIPTION
sometime sportsline-api.quantena.org sends `IndexPrice=""(during game). `handleMessage` in `src/sportsclient/ws.go, filtered (`Type != "odds"`) and logged the parse error but kept going,  so `px=0` was written to redis and published on `px_update`. trader-backend doesn't filter zeros, so the corrupted `indexPrice: 0` flows all the way through to WS subscribers. 


For candles side: 

```
docker service logs stack_candles-sports-client --since 30m --timestamps 2>&1 \
| grep '2026-05-27T16:53:5' | grep -E 'MIA_TOR_260527|invalid price'
```

shows that at 2026-05-27T16:53:57.141Z:

`
2026-05-27T16:53:57.141902657Z stack_candles-sports-client.1.yes5li0m6uuz@worker-01    | time=2026-05-27T16:53:57.141Z level=ERROR source=/d8x-candles/src/sportsclient/ws.go:85 msg="invalid price" price=""
2026-05-27T16:53:57.141948878Z stack_candles-sports-client.1.yes5li0m6uuz@worker-01    | time=2026-05-27T16:53:57.141Z level=INFO source=/d8x-candles/src/sportsclient/ws.go:105 msg="price update" contractId=MLB_MIA_TOR_260527 price="" event_status=0 <-- with a 0 event status
`


and at the same sec in the backend api: 

`2026-05-27T16:53:57.146314971Z stack_api.1.xo34moqhi0o7@worker-03    | {"index":"MLB_MIA_TOR_260527-PUSD","level":"info","message":"[@_updatePricesOnIndexPrice] routing","perpetualIds":[100040],"px":0,"service":"api","timestamp":"2026-05-27T16:53:57.145Z"}`

In redis the 0px price did live for ~7s:

```
  16:53:57.003  px was 0.5787   
  16:53:57.141    px was  0        <== here price sent was " "
  16:54:04.418  px was  0.5754  <==  ~7.3s after 
```
  
